### PR TITLE
Added aarch64 and musllinux support

### DIFF
--- a/.github/workflows/lint-test-cover-docs-build-upload.yml
+++ b/.github/workflows/lint-test-cover-docs-build-upload.yml
@@ -253,3 +253,175 @@ jobs:
         with:
           name: ${{ env.WHEELNAME }}
           path: rbcl-wheelhouse\
+
+  manylinux2014_aarch64:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - { version: '3.8', abi: 'cp38' }
+          - { version: '3.9', abi: 'cp39' }
+          - { version: '3.10', abi: 'cp310' }
+          - { version: '3.11', abi: 'cp311' }
+          - { version: '3.12', abi: 'cp312' }
+
+    name: Python ${{ matrix.python.version }} with ABI ${{ matrix.python.abi }} for manylinux2014_aarch64
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_ARCHS_LINUX: "aarch64"
+      CIBW_BUILD: "${{ matrix.python.abi }}-manylinux_aarch64"
+      CIBW_PROJECT_REQUIRES_PYTHON: ">=${{ matrix.python.version }}"
+      CIBW_ENVIRONMENT: LIBSODIUM_MAKE_ARGS="-j$(nproc)"
+      CIBW_BEFORE_ALL: >
+        pip install .[build] -v
+      CIBW_REPAIR_WHEEL_COMMAND: ""
+      CIBW_TEST_EXTRAS: "lint,test,docs"
+      CIBW_BEFORE_TEST: >
+        cd {project} &&
+        cp build/lib*/rbcl/_sodium.py src/rbcl/_sodium.py &&
+        pip3 install pystache~=0.6 setuptools &&
+        yum install wget -y &&
+        wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz &&
+        mv libsodium-1.0.18.tar.gz src/rbcl/libsodium.tar.gz
+      CIBW_TEST_COMMAND: >
+        cd {project} &&
+        python -m pylint rbcl src/rbcl/_sodium.tmpl src/rbcl/_sodium_build.py --disable=duplicate-code &&
+        python src/rbcl/rbcl.py -v &&
+        python -m pytest &&
+        cd docs &&
+        sphinx-apidoc -f -E --templatedir=_templates -o _source .. ../src/rbcl/_sodium_build.py ** &&
+        make html
+      CIBW_DEBUG_TRACEBACK: True
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        with:
+          output-dir: dist
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbcl-${{ github.ref_name }}-${{ matrix.python.abi }}-manylinux2014_aarch64
+          path: dist/*.whl
+
+
+  musllinux_1_2_aarch64:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - { version: '3.8', abi: 'cp38' }
+          - { version: '3.9', abi: 'cp39' }
+          - { version: '3.10', abi: 'cp310' }
+          - { version: '3.11', abi: 'cp311' }
+          - { version: '3.12', abi: 'cp312' }
+
+    name: Python ${{ matrix.python.version }} with ABI ${{ matrix.python.abi }} for musllinux_1_2_aarch64
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_ARCHS_LINUX: "aarch64"
+      CIBW_BUILD: "${{ matrix.python.abi }}-musllinux_aarch64"
+      CIBW_PROJECT_REQUIRES_PYTHON: ">=${{ matrix.python.version }}"
+      CIBW_ENVIRONMENT: LIBSODIUM_MAKE_ARGS="-j$(nproc)"
+      CIBW_BEFORE_ALL: >
+        pip install .[build] -v
+      CIBW_REPAIR_WHEEL_COMMAND: ""
+      CIBW_TEST_EXTRAS: "lint,test,docs"
+      CIBW_BEFORE_TEST: >
+        cd {project} &&
+        cp build/lib*/rbcl/_sodium.py src/rbcl/_sodium.py &&
+        pip3 install pystache~=0.6 setuptools &&
+        apk add wget &&
+        wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz &&
+        mv libsodium-1.0.18.tar.gz src/rbcl/libsodium.tar.gz
+      CIBW_TEST_COMMAND: >
+        cd {project} &&
+        python -m pylint rbcl src/rbcl/_sodium.tmpl src/rbcl/_sodium_build.py --disable=duplicate-code &&
+        python src/rbcl/rbcl.py -v &&
+        python -m pytest &&
+        cd docs &&
+        sphinx-apidoc -f -E --templatedir=_templates -o _source .. ../src/rbcl/_sodium_build.py ** &&
+        make html
+      CIBW_DEBUG_TRACEBACK: True
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        with:
+          output-dir: dist
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbcl-${{ github.ref_name }}-${{ matrix.python.abi }}-musllinux_1_2_aarch64
+          path: dist/*.whl
+
+
+
+  musllinux_1_2_x86_64:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - { version: '3.8', abi: 'cp38' }
+          - { version: '3.9', abi: 'cp39' }
+          - { version: '3.10', abi: 'cp310' }
+          - { version: '3.11', abi: 'cp311' }
+          - { version: '3.12', abi: 'cp312' }
+
+    name: Python ${{ matrix.python.version }} with ABI ${{ matrix.python.abi }} for musllinux_1_2_x86_64
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_ARCHS_LINUX: "x86_64"
+      CIBW_BUILD: "${{ matrix.python.abi }}-musllinux_x86_64"
+      CIBW_PROJECT_REQUIRES_PYTHON: ">=${{ matrix.python.version }}"
+      CIBW_ENVIRONMENT: LIBSODIUM_MAKE_ARGS="-j$(nproc)"
+      CIBW_BEFORE_ALL: >
+        pip install .[build] -v
+      CIBW_REPAIR_WHEEL_COMMAND: ""
+      CIBW_TEST_EXTRAS: "lint,test,docs"
+      CIBW_BEFORE_TEST: >
+        cd {project} &&
+        cp build/lib*/rbcl/_sodium.py src/rbcl/_sodium.py &&
+        pip3 install pystache~=0.6 setuptools &&
+        apk add wget &&
+        wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz &&
+        mv libsodium-1.0.18.tar.gz src/rbcl/libsodium.tar.gz
+      CIBW_TEST_COMMAND: >
+        cd {project} &&
+        python -m pylint rbcl src/rbcl/_sodium.tmpl src/rbcl/_sodium_build.py --disable=duplicate-code &&
+        python src/rbcl/rbcl.py -v &&
+        python -m pytest &&
+        cd docs &&
+        sphinx-apidoc -f -E --templatedir=_templates -o _source .. ../src/rbcl/_sodium_build.py ** &&
+        make html
+      CIBW_DEBUG_TRACEBACK: True
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        with:
+          output-dir: dist
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: rbcl-${{ github.ref_name }}-${{ matrix.python.abi }}-musllinux_1_2_x86_64
+          path: dist/*.whl

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ where=src
 build = setuptools>=67.6; wheel~=0.37; pystache~=0.6; build~=0.10
 docs = sphinx~=4.2.0; sphinx-rtd-theme~=1.0.0
 test = pytest~=7.2; pytest-cov~=4.0
-lint = pylint~=2.17.0
+lint = pylint~=3.2.7
 coveralls = coveralls~=3.3.1
 publish = twine~=4.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ where=src
 
 [options.extras_require]
 build = setuptools>=67.6; wheel~=0.37; pystache~=0.6; build~=0.10
-docs = sphinx~=4.2.0; sphinx-rtd-theme~=1.0.0
+docs = sphinx~=5.0.0; sphinx-rtd-theme~=1.0.0
 test = pytest~=7.2; pytest-cov~=4.0
 lint = pylint~=3.2.7
 coveralls = coveralls~=3.3.1

--- a/src/rbcl/_sodium_build.py
+++ b/src/rbcl/_sodium_build.py
@@ -12,7 +12,7 @@ import subprocess
 import tarfile
 import errno
 import urllib.request
-from distutils.sysconfig import get_config_vars # pylint: disable=deprecated-module
+from distutils.sysconfig import get_config_vars # pylint: disable=import-error,deprecated-module
 import pystache
 from setuptools.command.install import install
 


### PR DESCRIPTION
Hello!
I have added a wheel building workflow for aarch64 and musllinux since we are using this library for encryption on RPi 4 with Ubuntu and Home Assistant OS. This would be a huge help for us if you accept the PR and add the wheels to PyPi^

- 3 new jobs for wheels building for Python 3.8-3.12
- I have also disabled pylint import error for distutils since it's remove in 3.12
- I have updated sphinx and pylint packages versions for reasons of compatibility with Python 3.12 as well
-  !This caused Python 3.7 builds to fail. Would you consider removing 3.7 from runs?

[Here](https://github.com/PaTara43/rbcl/actions/runs/10826665919) is an Action summary

Thank you in advance!